### PR TITLE
chore: Skip devDependencies during deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  command = "npm i -g microbundle && npm run build && cd example && npm install && npm run build"
+
+[build.environment]
+  NODE_ENV = "production"


### PR DESCRIPTION
### Summary

Set `NODE_ENV` to `production` to skip the installation of `devDependencies`.

### Description

We want to deploy the example app in a `production` environment. There's no need to install the `devDependencies` of `bare-minimum-2d`.

When `devDependencies` are skipped, `microbundle` needs to be installed globally to run the build script.

This PR also creates a [Netlify configuration file][1] to document our Netlify configuration and track changes.

[1]: https://docs.netlify.com/configure-builds/file-based-configuration/
