### PR TITLE
chore: Install build tools but clear to avoid conflict

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm i -g microbundle && npm run build && cd example && npm install && npm run build"
+  command = "npm run build && rm -rf node_modules && cd example && npm install && npm run build"
 
 [build.environment]
-  NODE_ENV = "production"
+  NODE_ENV = "development"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "microbundle build --jsx React.createElement --format modern,cjs",
     "start": "microbundle watch --jsx React.createElement --format modern,cjs",
-    "prepare": "run-s build",
+    "prepublishOnly": "npm run build",
     "predeploy": "cd example && npm install && npm run build"
   },
   "peerDependencies": {
@@ -36,7 +36,6 @@
   "devDependencies": {
     "microbundle": "^0.12.3",
     "cross-env": "^7.0.2",
-    "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4"
   },
   "files": [


### PR DESCRIPTION
### Summary

In #20, we changed the environment to `production` to skip the `devDependencies`. However, we actually need these build tools (e.g. `microbundle`) to build the library but just don't want these packages in `node_modules` to exist when building the example app to avoid potential conflicts. This PR changes the environment back to `development` but clears `node_modules` after building the library.

In `development` environment, the `prepare` script is automatically run during `npm install` of the library and so the `microbundle build` gets executed twice (first during `npm install`, then during `npm run build`). We replace `prepare` with `prepublishOnly` to avoid this double execution and to also keep the build step when publishing. We also just want to avoid using the `prepare` script in general to avoid confusion and be explicit of the build step in the build command.
